### PR TITLE
Fix for using "symtom" consistently in Swedish

### DIFF
--- a/Koronavilkku/Koronavilkku/Localization/sv.lproj/Localizable.strings
+++ b/Koronavilkku/Koronavilkku/Localization/sv.lproj/Localizable.strings
@@ -88,7 +88,7 @@
 "PublishTokensViewController.Text.FinishedButton" = "OK";
 
 // MARK: SymptomsViewController
-"SymptomsViewController.Text.Heading" = "Bedömning av coronasymptom";
+"SymptomsViewController.Text.Heading" = "Bedömning av coronasymtom";
 "SymptomsViewController.Text.Body" = "Gör en bedömning av dina symtom i Omaolo, om du misstänker att du smittats av coronaviruset. Du får ytterligare anvisningar på basen av dina svar. Det räcker cirka 5-10 minuter att fylla i bedömningen.";
 "SymptomsViewController.Text.LinkTitle" = "Gör en symtombedömning i Omaolo";
 "SymptomsViewController.Text.LinkName" = "omaolo.fi";
@@ -136,7 +136,7 @@
 "HeaderContinueByAcceptingExposureLogging" = "Fortsätt aktiveringen genom att välja \"Tillåt\"";
 
 "ContactRequestItemTitle" = "Lämna en begäran att hälsovården kontaktar dig";
-"ContactRequestItemInfo" = "Avsätt ändast för 16 år fyllda, symptomfria personer";
+"ContactRequestItemInfo" = "Avsätt ändast för 16 år fyllda, symtomfria personer";
 
 "AlertErrorLoadingMunicipalities" = "Det gick inte att ladda kommunuppgifterna.";
 "AlertMessagePleaseTryAgainLater" = "Kontrollera anslutningen och försök på nytt.";


### PR DESCRIPTION
The Swedish translation so far mostly uses "symtom" instead of "symptom", even though both are valid.

This fixes the translation to consistently use "symtom".