### PR TITLE
Refactor EFGS country list update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - New UI components: Checkbox, RadioButton, FadeBlock and BulletItem
-- EFGSRepository for managing the EFGS interop information: initially it just updates the country list on every app launch and provides a method for retrieving the participating countries.
+- EFGSRepository for managing the EFGS interop information: initially just provides methods for storing and retrieving the participating countries.
 
 ### Changed
+- Component style changes and corrections: button shadows and colors, text colors, etc. 
 - Improve accessibility by adding new header traits and hints, better checkbox handling
-- The current infection reporting functionality has been replaced with more detailed UI flow that optionally lets the user share their diagnosis keys with the EFGS. 
+- The infection reporting functionality has been replaced with more detailed UI flow that optionally lets the user share their travel history and diagnosis keys with the EFGS. 
 
 ## 1.3.0
 

--- a/Koronavilkku/Koronavilkku/Environment.swift
+++ b/Koronavilkku/Koronavilkku/Environment.swift
@@ -24,8 +24,7 @@ extension Environment {
                                                   cache: LocalStore.shared,
                                                   storage: storage)
         
-        let efgsRepository = EFGSRepositoryImpl(backend: backend,
-                                                storage: storage)
+        let efgsRepository = EFGSRepositoryImpl(storage: storage)
 
         let exposureRepository = ExposureRepositoryImpl(efgsRepository: efgsRepository,
                                                         exposureManager: ExposureManagerProvider.shared.manager,

--- a/Koronavilkku/Koronavilkku/Repository/EFGSRepository.swift
+++ b/Koronavilkku/Koronavilkku/Repository/EFGSRepository.swift
@@ -38,7 +38,6 @@ protocol EFGSRepository {
 struct EFGSRepositoryImpl: EFGSRepository {
     static let countryListFile = "efgs-country-list"
     
-    let backend: Backend
     let storage: FileStorage
     
     func getParticipatingCountries() -> Set<EFGSCountry>? {
@@ -51,21 +50,6 @@ struct EFGSRepositoryImpl: EFGSRepository {
         }
         
         storage.write(object: countryList, to: Self.countryListFile)
-    }
-    
-    func updateCountryList() -> AnyPublisher<Bool, Never> {
-        backend.getConfiguration()
-            .map { config in
-                let countryList = config.participatingCountries.compactMap { regionCode in
-                    EFGSCountry.create(from: regionCode)
-                }
-                
-                return storage.write(object: countryList, to: Self.countryListFile)
-            }
-            .catch { _ in
-                Just(false)
-            }
-            .eraseToAnyPublisher()
     }
 }
 

--- a/Koronavilkku/Koronavilkku/Repository/EFGSRepository.swift
+++ b/Koronavilkku/Koronavilkku/Repository/EFGSRepository.swift
@@ -32,7 +32,7 @@ struct EFGSCountry: Codable, Hashable {
 /// positive COVID-19 diagnosis.
 protocol EFGSRepository {
     func getParticipatingCountries() -> Set<EFGSCountry>?
-    func updateCountryList() -> AnyPublisher<Bool, Never>
+    func updateCountryList(from: ExposureConfiguration)
 }
 
 struct EFGSRepositoryImpl: EFGSRepository {
@@ -43,6 +43,14 @@ struct EFGSRepositoryImpl: EFGSRepository {
     
     func getParticipatingCountries() -> Set<EFGSCountry>? {
         storage.read(from: Self.countryListFile)
+    }
+    
+    func updateCountryList(from config: ExposureConfiguration) {
+        let countryList = config.participatingCountries.compactMap { regionCode in
+            EFGSCountry.create(from: regionCode)
+        }
+        
+        storage.write(object: countryList, to: Self.countryListFile)
     }
     
     func updateCountryList() -> AnyPublisher<Bool, Never> {

--- a/Koronavilkku/Koronavilkku/Repository/FileStorage.swift
+++ b/Koronavilkku/Koronavilkku/Repository/FileStorage.swift
@@ -2,13 +2,15 @@ import Combine
 import Foundation
 
 protocol FileStorage {
-    // batch file accessors
+    // MARK: Batch file accessors
     func `import`(batchId: String, data: Data) throws -> String
     func getFileUrls(forBatchId id: String) -> [URL]
     func deleteAllBatches()
     
-    // generic object storage
+    // MARK: Generic object storage
+    @discardableResult
     func write<T: Codable>(object: T, to filename: String) -> Bool
+    
     func read<T: Codable>(from filename: String) -> T?
 }
 

--- a/Koronavilkku/Koronavilkku/Tools/LivePreview.swift
+++ b/Koronavilkku/Koronavilkku/Tools/LivePreview.swift
@@ -119,15 +119,14 @@ extension Environment {
         }
         
         struct PreviewEFGSRepository: EFGSRepository {
+            let state: PreviewState
+
             func getParticipatingCountries() -> Set<EFGSCountry>? {
                 Set()
             }
-            
-            func updateCountryList() -> AnyPublisher<Bool, Never> {
-                return Just(true).eraseToAnyPublisher()
+
+            func updateCountryList(from: ExposureConfiguration) {
             }
-            
-            let state: PreviewState
         }
         
         let state = createState()

--- a/Koronavilkku/Koronavilkku/UI/Components/RoundedButton.swift
+++ b/Koronavilkku/Koronavilkku/UI/Components/RoundedButton.swift
@@ -14,7 +14,7 @@ class RoundedButton: UIButton {
                 backgroundColor = isHighlighted ? highlightedBackgroundColor : enabledBackgroundColor
             }
 
-            layer.shadowColor = isHighlighted ? UIColor.clear.cgColor : UIColor.Greyscale.lightGrey.cgColor
+            layer.shadowColor = isHighlighted ? UIColor.clear.cgColor : .dropShadow
         }
     }
     
@@ -43,7 +43,7 @@ class RoundedButton: UIButton {
     let title: String
     let action: () -> ()
     
-    private let disabledBackgroundColor = UIColor.Greyscale.lightGrey
+    private let disabledBackgroundColor = UIColor.Greyscale.borderGrey
     private let enabledBackgroundColor: UIColor
     private let highlightedBackgroundColor: UIColor
     
@@ -96,7 +96,7 @@ class RoundedButton: UIButton {
     
     func setEnabled(_ enabled: Bool) {
         isEnabled = enabled
-        alpha = enabled ? 1.0 : 0.5
+        layer.shadowColor = enabled ? .dropShadow : UIColor.clear.cgColor
         backgroundColor = enabled ? enabledBackgroundColor : disabledBackgroundColor
     }
     

--- a/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/ChooseDestinationViewController.swift
+++ b/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/ChooseDestinationViewController.swift
@@ -24,11 +24,12 @@ class ChooseDestinationViewController: BaseReportInfectionViewController {
         continueButton.setEnabled(false)
         createContentWrapper(floatingButton: continueButton)
 
-        let titleView = UILabel(label: Text.Title.localized,
+        let titleLabel = UILabel(label: Text.Title.localized,
                                 font: .heading3,
                                 color: UIColor.Greyscale.black)
         
-        titleView.numberOfLines = 0
+        titleLabel.numberOfLines = 0
+        titleLabel.accessibilityTraits = .header
         
         let radioEFGS = RadioButton(value: ReportingDestination.efgs,
                                     label: Text.DestinationEFGS.localized)
@@ -46,7 +47,7 @@ class ChooseDestinationViewController: BaseReportInfectionViewController {
         hasTokenLabel.textAlignment = .center
         
         content.layout { append in
-            append(titleView, nil)
+            append(titleLabel, nil)
             append(CardElement(embed: radioEFGS), UIEdgeInsets(top: 20))
             append(CardElement(embed: radioLocal), UIEdgeInsets(top: 20))
             append(hasTokenLabel, UIEdgeInsets(top: 40))

--- a/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/ConfirmReportViewController.swift
+++ b/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/ConfirmReportViewController.swift
@@ -27,7 +27,8 @@ class ConfirmReportViewController: BaseReportInfectionViewController {
 
         let titleLabel = UILabel(label: Text.Title.localized, font: .heading2, color: UIColor.Greyscale.black)
         titleLabel.numberOfLines = 0
-        
+        titleLabel.accessibilityTraits = .header
+
         let messageLabel = UILabel(label: getMessage().localized, font: .bodySmall, color: UIColor.Greyscale.black)
         messageLabel.numberOfLines = 0
         

--- a/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/TravelStatusViewController.swift
+++ b/Koronavilkku/Koronavilkku/ViewController/ReportInfectionFlow/TravelStatusViewController.swift
@@ -21,12 +21,13 @@ class TravelStatusViewController: BaseReportInfectionViewController {
         continueButton.setEnabled(false)
         createContentWrapper(floatingButton: continueButton)
 
-        let titleView = UILabel(label: Text.Title.localized,
+        let titleLabel = UILabel(label: Text.Title.localized,
                                 font: .heading3,
                                 color: UIColor.Greyscale.black)
         
-        titleView.numberOfLines = 0
-        
+        titleLabel.numberOfLines = 0
+        titleLabel.accessibilityTraits = .header
+
         let radioNotTravelled = RadioButton(value: false,
                                             label: Text.NotTravelled.localized)
         
@@ -36,7 +37,7 @@ class TravelStatusViewController: BaseReportInfectionViewController {
         self.radioButtonGroup = RadioButtonGroup([radioNotTravelled, radioHasTravelled])
         
         content.layout { append in
-            append(titleView, nil)
+            append(titleLabel, nil)
             append(CardElement(embed: radioNotTravelled), UIEdgeInsets(top: 20))
             append(CardElement(embed: radioHasTravelled), UIEdgeInsets(top: 20))
         }

--- a/Koronavilkku/Koronavilkku/ViewController/RootViewController.swift
+++ b/Koronavilkku/Koronavilkku/ViewController/RootViewController.swift
@@ -23,14 +23,14 @@ class RootViewController : UITabBarController {
         updateTask = Publishers.Zip(
             // In case a considerable amount of time (batch id changes) elapses before
             // the background task is run the first time, attempt to fetch the current batch identifier separately.
-            Environment.default.batchRepository.getCurrentBatchId().catch { _ in
-                Empty(completeImmediately: true)
-            },
+            Environment.default.batchRepository.getCurrentBatchId(),
             
             // Update the EFGS country list
-            Environment.default.efgsRepository.updateCountryList()
+            Environment.default.exposureRepository.getConfiguration()
         )
-        .sink { _ in }
+        .sink { _ in } receiveValue: { _, config in
+            Environment.default.efgsRepository.updateCountryList(from: config)
+        }
         
         // Set every UILabel automagically respond to Dynamic Type changes
         UILabel.appearance().adjustsFontForContentSizeCategory = true

--- a/Koronavilkku/Koronavilkku/ViewController/TestViewController.swift
+++ b/Koronavilkku/Koronavilkku/ViewController/TestViewController.swift
@@ -12,8 +12,7 @@ class TestViewController: UIViewController {
     
     lazy var storeBatchIdButton = self.createButton(title: "Store batch id", action: #selector(storeBatchId))
     lazy var testBatchDownloadButton = self.createButton(title: "Test batch loading", action: #selector(batchDownloadPressed))
-    lazy var testBatchDownloadInTheBackgroundButton = self.createButton(title: "Test background batch", action: #selector(batchDownloadBackgroundPressed))
-    lazy var downloadAndDetectButton = self.createButton(title: "Dl and detect", action: #selector(downloadAndDetect))
+    lazy var downloadAndDetectButton = self.createButton(title: "Run exposure detection", action: #selector(downloadAndDetect))
     lazy var addExposureButton = self.createButton(title: "Add exposure", action: #selector(addExposure))
     lazy var addExposureDelayedButton = self.createButton(title: "Add exposure, delayed", action: #selector(addExposureDelayed))
     lazy var addLegacyExposureButton = self.createButton(title: "Add legacy exposure", action: #selector(addLegacyExposure))
@@ -73,7 +72,6 @@ class TestViewController: UIViewController {
         
         appendButton(testBatchDownloadButton)
         appendButton(downloadAndDetectButton)
-        appendButton(testBatchDownloadInTheBackgroundButton)
         appendButton(addExposureButton)
         appendButton(addExposureDelayedButton)
         appendButton(addLegacyExposureButton)
@@ -123,17 +121,6 @@ class TestViewController: UIViewController {
                     Log.e("Failed to download and detect")
                 }
             }.store(in: &tasks)
-    }
-    
-    @objc func batchDownloadBackgroundPressed() {
-        let taskRequest = BGProcessingTaskRequest(identifier: BackgroundTaskManager.shared.identifier(for: .notifications))
-        taskRequest.requiresNetworkConnectivity = true
-        do {
-            Log.d("Submitting background task")
-            try BGTaskScheduler.shared.submit(taskRequest)
-        } catch {
-            Log.e("Could not schedule batch download: \(error)")
-        }
     }
     
     @objc func addExposure() {

--- a/Koronavilkku/KoronavilkkuTests/Mock/MockEFGSRepository.swift
+++ b/Koronavilkku/KoronavilkkuTests/Mock/MockEFGSRepository.swift
@@ -8,7 +8,6 @@ struct MockEFGSRepository : EFGSRepository {
         participatingCountries
     }
     
-    func updateCountryList() -> AnyPublisher<Bool, Never> {
-        return Just(true).eraseToAnyPublisher()
+    func updateCountryList(from: ExposureConfiguration) {
     }
 }


### PR DESCRIPTION
Instead of just running the country list updating sequence on every app launch, update it also when checking for exposures in the background task, as we're already loading the configuration object there.

Smaller changes:

* Added missing accessibility traits
* The RoundedButton disabled state was incorrectly partially transparent and had a shadow
* Removed the no longer needed background task scheduling tool from the test UI