### PR TITLE
Change exposure notification retention time back to 14 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Adjust the exposure notification retention time and the detection interval duration back to 14 days
+
 ## 2.0.0
 
 ### Added

--- a/Koronavilkku/Koronavilkku/Localization/en.lproj/Localizable.strings
+++ b/Koronavilkku/Koronavilkku/Localization/en.lproj/Localizable.strings
@@ -54,13 +54,13 @@
 "ExposuresViewController.Text.TitleHasExposures" = "Potential exposure";
 
 // MARK: ExposuresViewWrapper
-"ExposuresViewWrapper.HasExposureText.Heading" = "In the past 10 days, you have been close to a person who has reported a COVID-19 infection.";
+"ExposuresViewWrapper.HasExposureText.Heading" = "In the past 14 days, you have been close to a person who has reported a COVID-19 infection.";
 "ExposuresViewWrapper.HasExposureText.ContactCardTitle" = "Contact healthcare services";
 "ExposuresViewWrapper.HasExposureText.ContactCardText" = "Information about your potential exposure will only be communicated to healthcare services if you contact them yourself.";
 "ExposuresViewWrapper.HasExposureText.ContactButtonTitle" = "Contact";
 "ExposuresViewWrapper.HasExposureText.ExposuresButtonTitle" = "Show exposure notifications";
 "ExposuresViewWrapper.HasExposureText.InstructionsTitle" = "What should I do?";
-"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Follow these instructions for 10 days:";
+"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Follow these instructions for 14 days:";
 "ExposuresViewWrapper.HasExposureText.InstructionsSymptoms" = "Monitor your health. If you develop any symptom consistent with COVID-19, contact your municipal healthcare service and get tested as soon as possible. Symptoms consistent with COVID-19 are change in sense of smell or taste, shortness of breath, cough, sore throat, runny nose, fever, headaches, muscle pain, unexplained diarrhoea or abdominal pain.";
 "ExposuresViewWrapper.HasExposureText.InstructionsDistancing" = "Avoid meeting other people.";
 "ExposuresViewWrapper.HasExposureText.InstructionsHygiene" = "Maintain good hand hygiene.";
@@ -71,7 +71,7 @@
 "ExposuresViewWrapper.HasExposureText.InstructionsWhenAbroad" = "If you are not in Finland, follow any instructions given by local authorities.";
 
 "ExposuresViewWrapper.NoExposuresText.Heading" = "No observed exposures";
-"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Koronavilkku has not detected exposures to the coronavirus in the last 10 days.";
+"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Koronavilkku has not detected exposures to the coronavirus in the last 14 days.";
 "ExposuresViewWrapper.NoExposuresText.DisclaimerText" = "However, the application is not able to identify every situation where exposure may occur.";
 
 "ExposuresLastCheckedView.Text.LastCheckedAt" = "Last checked %@";
@@ -79,7 +79,7 @@
 "ExposuresLastCheckedView.Text.NotCheckedYet" = "No checks yet";
 
 "NotificationListViewController.Text.Title" = "Exposure notifications";
-"NotificationListViewController.Text.Disclaimer" = "The assessment of your exposure is based on encounters that Koronavilkku has collected during the last 10 days. The intensity of exposure cannot be accurately assessed.";
+"NotificationListViewController.Text.Disclaimer" = "The assessment of your exposure is based on encounters that Koronavilkku has collected during the last 14 days. The intensity of exposure cannot be accurately assessed.";
 "NotificationListViewController.Text.ItemTitle" = "Notification about potential exposure %@";
 "NotificationListViewController.Text.ItemCountLabel" = "Potential exposures";
 "NotificationListViewController.Text.ItemCountValue" = "%@ pcs.";

--- a/Koronavilkku/Koronavilkku/Localization/fi.lproj/Localizable.strings
+++ b/Koronavilkku/Koronavilkku/Localization/fi.lproj/Localizable.strings
@@ -54,13 +54,13 @@
 "ExposuresViewController.Text.TitleHasExposures" = "Mahdollinen altistuminen";
 
 // MARK: ExposuresViewWrapper
-"ExposuresViewWrapper.HasExposureText.Heading" = "Olet ollut viimeisten 10 vuorokauden aikana lähellä henkilöä, joka on ilmoittanut korona\U00ADtartunnastaan sovelluksen kautta.";
+"ExposuresViewWrapper.HasExposureText.Heading" = "Olet ollut viimeisten 14 vuorokauden aikana lähellä henkilöä, joka on ilmoittanut korona\U00ADtartunnastaan sovelluksen kautta.";
 "ExposuresViewWrapper.HasExposureText.ContactCardTitle" = "Ota yhteyttä terveydenhuoltoon";
 "ExposuresViewWrapper.HasExposureText.ContactCardText" = "Tieto mahdollisesta altistumisestasi ei välity terveydenhuoltoon, jollet itse ota yhteyttä.";
 "ExposuresViewWrapper.HasExposureText.ContactButtonTitle" = "Ota yhteyttä";
 "ExposuresViewWrapper.HasExposureText.ExposuresButtonTitle" = "Katso altistumis\U00ADilmoitukset";
 "ExposuresViewWrapper.HasExposureText.InstructionsTitle" = "Toimi näin";
-"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Noudata näitä ohjeita 10 päivän ajan:";
+"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Noudata näitä ohjeita 14 päivän ajan:";
 "ExposuresViewWrapper.HasExposureText.InstructionsSymptoms" = "Tarkkaile vointiasi. Jos sinulla ilmenee yksikin koronavirustautiin sopiva oire, ota mahdollisimman pian yhteyttä kuntasi terveydenhuoltoon ja hakeudu testiin. Koronavirustautiin sopivia oireita ovat haju- tai makuaistin muutos, hengitysvaikeus, yskä, kurkkukipu, nuha, kuume, päänsärky, lihaskivut sekä ripuli tai vatsakipu ilman muuta ilmeistä syytä.";
 "ExposuresViewWrapper.HasExposureText.InstructionsDistancing" = "Vältä tapaamasta muita ihmisiä.";
 "ExposuresViewWrapper.HasExposureText.InstructionsHygiene" = "Huolehdi käsihygieniastasi.";
@@ -71,7 +71,7 @@
 "ExposuresViewWrapper.HasExposureText.InstructionsWhenAbroad" = "Jos et ole Suomessa, noudata paikallisten viranomaisten ohjeita.";
 
 "ExposuresViewWrapper.NoExposuresText.Heading" = "Ei havaittuja altistumisia";
-"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Koronavilkku ei ole havainnut altistumista koronavirukselle viimeisten 10 päivän aikana.";
+"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Koronavilkku ei ole havainnut altistumista koronavirukselle viimeisten 14 päivän aikana.";
 "ExposuresViewWrapper.NoExposuresText.DisclaimerText" = "Sovellus ei kuitenkaan tunnista kaikkia mahdollisia altistumis\U00ADtilanteita.";
 
 "ExposuresLastCheckedView.Text.LastCheckedAt" = "Tarkistettu viimeksi %@";
@@ -79,7 +79,7 @@
 "ExposuresLastCheckedView.Text.NotCheckedYet" = "Altistumistietoja ei ole vielä tarkistettu";
 
 "NotificationListViewController.Text.Title" = "Altistumis\U00ADilmoitukset";
-"NotificationListViewController.Text.Disclaimer" = "Arvio altistumisesta perustuu Koronavilkun keräämiin kohtaamistietoihin viimeisten 10 vuorokauden ajalta. Altistumisen voimakkuutta ei voida täsmällisesti arvioida.";
+"NotificationListViewController.Text.Disclaimer" = "Arvio altistumisesta perustuu Koronavilkun keräämiin kohtaamistietoihin viimeisten 14 vuorokauden ajalta. Altistumisen voimakkuutta ei voida täsmällisesti arvioida.";
 "NotificationListViewController.Text.ItemTitle" = "Altistumisilmoitus %@";
 "NotificationListViewController.Text.ItemCountLabel" = "Mahdollisia altistumisia";
 "NotificationListViewController.Text.ItemCountValue" = "%@ kpl";

--- a/Koronavilkku/Koronavilkku/Localization/sv.lproj/Localizable.strings
+++ b/Koronavilkku/Koronavilkku/Localization/sv.lproj/Localizable.strings
@@ -54,13 +54,13 @@
 "ExposuresViewController.Text.TitleHasExposures" = "Eventuell exponering";
 
 // MARK: ExposuresViewWrapper
-"ExposuresViewWrapper.HasExposureText.Heading" = "Du har under de senaste 10 dygnen varit i närheten av en person som meddelat om sin coronasmitta via applikationen.";
+"ExposuresViewWrapper.HasExposureText.Heading" = "Du har under de senaste 14 dygnen varit i närheten av en person som meddelat om sin coronasmitta via applikationen.";
 "ExposuresViewWrapper.HasExposureText.ContactCardTitle" = "Kontakta hälsovården";
 "ExposuresViewWrapper.HasExposureText.ContactCardText" = "Information om eventuell exponering förmedlas till hälsovården endast om du själv tar kontakt.";
 "ExposuresViewWrapper.HasExposureText.ContactButtonTitle" = "Ta kontakt";
 "ExposuresViewWrapper.HasExposureText.ExposuresButtonTitle" = "Visa exponerings\U00ADmeddelandena";
 "ExposuresViewWrapper.HasExposureText.InstructionsTitle" = "Gör så här";
-"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Följ dessa anvisningar i 10 dagar:";
+"ExposuresViewWrapper.HasExposureText.InstructionsLede" = "Följ dessa anvisningar i 14 dagar:";
 "ExposuresViewWrapper.HasExposureText.InstructionsSymptoms" = "Var uppmärksam på hur du mår. Om du har ens ett av symtomen som passar in på coronavirus\U00ADinfektion, ta så snabbt som möjligt kontakt med hälsovården i din kommun för att bli testad. Symtom som kan tyda på coronavirus\U00ADinfektion är förändringar i lukt- eller smaksinnet, andningssvårigheter, hosta, halsont, snuva, feber, huvudvärk, muskelvärk samt diarré eller magont utan annan uppenbar orsak.";
 "ExposuresViewWrapper.HasExposureText.InstructionsDistancing" = "Undvik att träffa andra människor.";
 "ExposuresViewWrapper.HasExposureText.InstructionsHygiene" = "Var noggrann med din handhygien.";
@@ -71,7 +71,7 @@
 "ExposuresViewWrapper.HasExposureText.InstructionsWhenAbroad" = "Om du inte befinner dig i Finland ska du följa de lokala myndigheternas anvisningar.";
 
 "ExposuresViewWrapper.NoExposuresText.Heading" = "Ingen exponering har upptäckts";
-"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Coronablinkern har inte observerat någon exponering för coronaviruset under de senaste 10 dagarna.";
+"ExposuresViewWrapper.NoExposuresText.Subtitle" = "Coronablinkern har inte observerat någon exponering för coronaviruset under de senaste 14 dagarna.";
 "ExposuresViewWrapper.NoExposuresText.DisclaimerText" = "Appen kan emellertid inte identifiera alla eventuella exponeringar.";
 
 "ExposuresLastCheckedView.Text.LastCheckedAt" = "Senast granskad %@";
@@ -79,7 +79,7 @@
 "ExposuresLastCheckedView.Text.NotCheckedYet" = "Ingen kontroll ännu";
 
 "NotificationListViewController.Text.Title" = "Exponerings\U00ADmeddelandena";
-"NotificationListViewController.Text.Disclaimer" = "Bedömningen om exponeringen bygger på den information om möten som Coronablinkern har samlat in under de senaste 10 dygnen. Coronablinkern ger ingen exakt bedömning av hur stor smittorisken är.";
+"NotificationListViewController.Text.Disclaimer" = "Bedömningen om exponeringen bygger på den information om möten som Coronablinkern har samlat in under de senaste 14 dygnen. Coronablinkern ger ingen exakt bedömning av hur stor smittorisken är.";
 "NotificationListViewController.Text.ItemTitle" = "Meddelande om eventuell exponering %@";
 "NotificationListViewController.Text.ItemCountLabel" = "Eventuella exponeringar";
 "NotificationListViewController.Text.ItemCountValue" = "%@ st.";

--- a/Koronavilkku/Koronavilkku/Model/ExposureModel.swift
+++ b/Koronavilkku/Koronavilkku/Model/ExposureModel.swift
@@ -7,18 +7,21 @@ enum ExposureStatus: Equatable {
 }
 
 struct ExposureNotification: Codable {
-    /// How long the notification is being shown after the exposure
-    ///
-    /// The official exposure retention time is 10 * 24 hours from the time of exposure.
-    /// As we don't know the exact time of exposure, just the 24-hour window starting
-    /// from 00:00 UTC, we need to add one additional 24-hour window to make sure every
-    /// possible exposure is covered.
-    static let retentionTime: TimeInterval = .days(10 + 1)
+    typealias Days = Double
     
-    /// Detection duration is 10 days long
-    static let detectionIntervalDuration: TimeInterval = .days(9)
-    static let detectionIntervalStart: TimeInterval = .days(-10)
-
+    /// The number of days an exposure notification is being shown after the exposure
+    ///
+    /// This property could be moved to the configuration, but as our UI texts are
+    /// currently static, this is also fixed.
+    static let exposureNotificationValid: Days = 14
+    
+    /// The number of days exposure detection goes back in time to find potential exposures
+    ///
+    /// While this value could be determined from the EN configuration, V1 API does not
+    /// provide enough granularity we need. We can revisit this issue later once we've moved
+    /// to the V2 API.
+    static let exposureDetectionInterval: Days = 14
+    
     let detectedOn: Date
     let expiresOn: Date
     let detectionInterval: DateInterval
@@ -26,10 +29,29 @@ struct ExposureNotification: Codable {
     
     init(detectionTime: Date, latestExposureOn: Date, exposureCount: Int) {
         self.detectedOn = detectionTime
-        self.expiresOn = latestExposureOn.addingTimeInterval(ExposureNotification.retentionTime)
-        self.detectionInterval = DateInterval(start: detectionTime.addingTimeInterval(Self.detectionIntervalStart),
-                                              duration: Self.detectionIntervalDuration)
+        self.expiresOn = ExposureNotification.calculateRetentionTime(timeOfExposure: latestExposureOn)
+        self.detectionInterval = ExposureNotification.calculateDetectionInterval(from: detectionTime)
         self.exposureCount = exposureCount
+    }
+
+    /// Determines the exposure notification retention time
+    ///
+    /// The official exposure retention time is calculated from the time of exposure.
+    /// As we don't know the exact time of exposure, just the 24-hour window starting
+    /// from 00:00 UTC, we need to add one additional 24-hour window to make sure every
+    /// possible exposure is covered.
+    static func calculateRetentionTime(timeOfExposure: Date) -> Date {
+        timeOfExposure.addingTimeInterval(.days(Self.exposureNotificationValid + 1))
+    }
+    
+    /// Calculates the date range used to detect exposures from the detection time
+    ///
+    /// The interval does not contain the current day, as our current implementation
+    /// creates the batch files from the TEK's issued in the previous day. Therefore the
+    /// interval is "one day shorter".
+    static func calculateDetectionInterval(from detectionTime: Date) -> DateInterval {
+        .init(start: detectionTime.addingTimeInterval(.days(0 - Self.exposureDetectionInterval)),
+              duration: .days(Self.exposureDetectionInterval - 1))
     }
 }
 
@@ -60,8 +82,11 @@ extension Collection where Element : ENExposureInfo {
 ///
 /// - Important: Deprecated, use ExposureNotification instead
 struct Exposure: Codable {
-    // Keep using the old retention time here to avoid problems if the ExposureNotification
-    // retention time changes in the future
+    /// How long the notification is being shown after the exposure
+    ///
+    /// We're still using the old value here on purpose, because the retention
+    /// time is a computed property based on this value and this is the last
+    /// value we have shipped and therefore is the most likely expiration time.
     static let retentionTime: TimeInterval = .days(10 + 1)
     
     let date: Date

--- a/Koronavilkku/KoronavilkkuTests/Model/ExposureModelTests.swift
+++ b/Koronavilkku/KoronavilkkuTests/Model/ExposureModelTests.swift
@@ -52,8 +52,8 @@ class ExposureModelTests: XCTestCase {
         
         XCTAssertEqual(
             notification.detectionInterval.start,
-            Calendar.current.date(byAdding: .day, value: -10, to: detectionTime),
-            "The detection interval starts from 10 days ago")
+            Calendar.current.date(byAdding: .day, value: -14, to: detectionTime),
+            "The detection interval starts from 14 days ago")
         
         XCTAssertEqual(
             notification.detectionInterval.end,
@@ -64,8 +64,8 @@ class ExposureModelTests: XCTestCase {
         // to cover exposures that have happened during the day
         XCTAssertEqual(
             notification.expiresOn,
-            Calendar.current.date(byAdding: .day, value: 11, to: exposureDate2),
-            "The notification should expire after 10 days from the last detected exposure")
+            Calendar.current.date(byAdding: .day, value: 15, to: exposureDate2),
+            "The notification should expire after 14 days from the last detected exposure")
 
         XCTAssertEqual(notification.exposureCount, 2)
     }
@@ -86,7 +86,7 @@ class ExposureModelTests: XCTestCase {
 
         XCTAssertEqual(
             notification.expiresOn,
-            Calendar.current.date(byAdding: .day, value: 11, to: latestExposureDate),
+            Calendar.current.date(byAdding: .day, value: 15, to: latestExposureDate),
             "The expiration date should be relative to the latest exposure")
         
         XCTAssertEqual(
@@ -107,7 +107,7 @@ class ExposureModelTests: XCTestCase {
         // we have no other dates to fix this to
         XCTAssertEqual(
             notification.expiresOn,
-            Calendar.current.date(byAdding: .day, value: 11, to: detectionDate),
+            Calendar.current.date(byAdding: .day, value: 15, to: detectionDate),
             "The expiration date should be relative to the detection date")
 
         XCTAssertEqual(


### PR DESCRIPTION
Due to the [recent policy changes](https://thl.fi/en/web/thlfi-en/-/quarantine-of-persons-exposed-to-coronavirus-extended-to-14-days), both exposure notification retention time and the number of days used to detect exposures is extended back to 14 days.