### PR TITLE
Owasp dependency scan changes (minor)

### DIFF
--- a/.github/docker-owasp-dependency-check-ios/Dockerfile
+++ b/.github/docker-owasp-dependency-check-ios/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:11
 
-ENV OWASP_DEPENDENCY_CHECK_ZIP_URL https://github.com/jeremylong/DependencyCheck/releases/download/v6.0.3/dependency-check-6.0.3-release.zip
+ENV OWASP_DEPENDENCY_CHECK_ZIP_URL https://github.com/jeremylong/DependencyCheck/releases/download/v6.1.0/dependency-check-6.1.0-release.zip
 
 RUN wget --quiet --output-document=dependency-check.zip $OWASP_DEPENDENCY_CHECK_ZIP_URL
 RUN unzip -qq dependency-check.zip -d /owasp

--- a/.github/workflows/dependency-scan.yml
+++ b/.github/workflows/dependency-scan.yml
@@ -59,7 +59,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          text: "OWASP dependency check"
+          text: "OWASP dependency check - trunk"
           status: ${{job.status}}
       - name: Notify by email
         if: ${{ github.event_name == 'schedule' && failure() }}

--- a/.github/workflows/release-dependency-scan.yml
+++ b/.github/workflows/release-dependency-scan.yml
@@ -63,7 +63,7 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         with:
-          text: "OWASP dependency check"
+          text: "OWASP dependency check - release"
           status: ${{job.status}}
       - name: Notify by email
         if: ${{ failure() }}


### PR DESCRIPTION
- slack notification states if trunk or release scanned
- bumped dependency scan to version 6.1.0
